### PR TITLE
Add additional hardening for unbound

### DIFF
--- a/scripts/unbound-setup.sh
+++ b/scripts/unbound-setup.sh
@@ -23,7 +23,13 @@ server:
     do-udp: yes
     do-tcp: yes
     do-ip6: yes
+    access-control: 127.0.0.0/8 allow
+    access-control: 0.0.0.0/0 deny
+    access-control: ::1 allow
+    access-control: ::0/0 deny
     prefer-ip6: no
+    hide-identity: yes
+    hide-version: yes
     harden-glue: yes
     harden-dnssec-stripped: yes
     use-caps-for-id: no


### PR DESCRIPTION
Don't rely purely on iptables, add defense in depth:
- Add access controls to only listen on localhost: Only Pi-hole should be querying unbound and only over localhost
- Disallow version and identify queries