### PR TITLE
Lock SSH in image

### DIFF
--- a/main.pkr.hcl
+++ b/main.pkr.hcl
@@ -31,17 +31,11 @@ build {
   # Update the base image
   provisioner "shell" {
     scripts = [
-      "scripts/ssh-lock.sh",
       "scripts/system-setup.sh",
-      "scripts/ssh-unlock.sh"
     ]
   }
 
   # Setup system on first boot after provisioning
-  provisioner "file" {
-    source      = "scripts/ssh-lock.sh"
-    destination = "/tmp/"
-  }
   provisioner "file" {
     source      = "scripts/system-setup.sh"
     destination = "/tmp/"
@@ -53,10 +47,8 @@ build {
   provisioner "shell" {
     inline = [
       "mkdir -p                 /var/lib//cloud/scripts/per-instance/",
-      "mv /tmp/ssh-lock.sh      /var/lib/cloud/scripts/per-instance/01-lock-ssh.sh",
-      "chmod 700                /var/lib/cloud/scripts/per-instance/01-lock-ssh.sh",
-      "mv /tmp/system-setup.sh  /var/lib/cloud/scripts/per-instance/02-setup-system.sh",
-      "chmod 700                /var/lib/cloud/scripts/per-instance/02-setup-system.sh",
+      "mv /tmp/system-setup.sh  /var/lib/cloud/scripts/per-instance/01-setup-system.sh",
+      "chmod 700                /var/lib/cloud/scripts/per-instance/01-setup-system.sh",
       "mv /tmp/ssh-unlock.sh    /var/lib/cloud/scripts/per-instance/09-unlock-ssh.sh",
       "chmod 700                /var/lib/cloud/scripts/per-instance/09-unlock-ssh.sh"
     ]
@@ -71,8 +63,8 @@ build {
   provisioner "shell" {
     inline = [
       "mkdir -p                 /var/lib/cloud/scripts/per-instance/",
-      "cp /tmp/wg-setup.sh      /var/lib/cloud/scripts/per-instance/03-setup-wireguard.sh",
-      "chmod 700                /var/lib/cloud/scripts/per-instance/03-setup-wireguard.sh",
+      "cp /tmp/wg-setup.sh      /var/lib/cloud/scripts/per-instance/02-setup-wireguard.sh",
+      "chmod 700                /var/lib/cloud/scripts/per-instance/02-setup-wireguard.sh",
       "mv /tmp/wg-setup.sh      /root/regen-vpn-keys.sh",
       "chmod 700                /root/regen-vpn-keys.sh"
     ]
@@ -86,8 +78,8 @@ build {
   provisioner "shell" {
     inline = [
       "mkdir -p                 /var/lib/cloud/scripts/per-instance/",
-      "mv /tmp/pihole-setup.sh  /var/lib/cloud/scripts/per-instance/04-setup-pihole.sh",
-      "chmod 700                /var/lib/cloud/scripts/per-instance/04-setup-pihole.sh",
+      "mv /tmp/pihole-setup.sh  /var/lib/cloud/scripts/per-instance/03-setup-pihole.sh",
+      "chmod 700                /var/lib/cloud/scripts/per-instance/03-setup-pihole.sh",
     ]
   }
 
@@ -99,8 +91,8 @@ build {
   provisioner "shell" {
     inline = [
       "mkdir -p                 /var/lib/cloud/scripts/per-instance/",
-      "mv /tmp/unbound-setup.sh /var/lib/cloud/scripts/per-instance/05-setup-unbound.sh",
-      "chmod 700                /var/lib/cloud/scripts/per-instance/05-setup-unbound.sh",
+      "mv /tmp/unbound-setup.sh /var/lib/cloud/scripts/per-instance/04-setup-unbound.sh",
+      "chmod 700                /var/lib/cloud/scripts/per-instance/04-setup-unbound.sh",
     ]
   }
 
@@ -108,6 +100,7 @@ build {
   provisioner "shell" {
     scripts = [
       "scripts/image-cleanup.sh",
+      "scripts/ssh-lock.sh",
       "scripts/image-check.sh"
     ]
   }

--- a/scripts/ssh-lock.sh
+++ b/scripts/ssh-lock.sh
@@ -14,7 +14,6 @@
 echo "Lock SSH during system setup ..."
 cat >> /etc/ssh/sshd_config <<EOM
 Match User root
-        ForceCommand echo "Please wait while we perform initial setup ..."
+    ForceCommand printf "Please wait while we perform initial setup....\n\nNB: If you attempt to SSH in too frequently, the firewall will temporarily lock you out.\nWe recommend putting a sleep 15 after your ssh command, e.g.\n\n    ssh root@\$(ip -4 a s scope global eth0 | grep 'inet ' | grep -v 'inet 10\.' | awk -F'[ \t/]+' '{printf \$3}') || sleep 15\n\n"; false
 EOM
-systemctl restart ssh
 echo "SSH locked."


### PR DESCRIPTION
Lock SSH in image instead of during first boot. Locking SSH on first boot is racey and allows a user to login before setup is complete By locking in the image, it prevents this race.

Also, provide feedback to user to help them avoid being temporarily blocked by firewall during first boot.